### PR TITLE
Updated docker-compose.yml file and command to avoid build cache issu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ mkarchiso -v -w /archiso-tmp -o ../ .
 ```
 
 ## With Docker
-
-(Edit `docker-compose.yml`) first to add your volume path
+Execute the following Docker command to build a fresh image each time:
 ```
-docker build -t arselinux-build . --no-cache
-docker compose up
+docker-compose build --force-rm --no-cache && docker-compose up
 ```
 
 Once completed you will have an ISO image to test/boot. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   arselinux-build:
     container_name: arselinux-build
-    image: 'arselinux:latest'
+    build: .
     restart: unless-stopped
     privileged: true
     volumes:


### PR DESCRIPTION
…e #8
For issue #8 
I have updated the command to build without any cache issue. And the docker image name was different, we were building as "arselinux-build" but trying to use "arselinux:latest" image from docker-compose.yml file. I have done the needful to avoid any confusion.